### PR TITLE
Allow to open file by current word

### DIFF
--- a/keymaps/atom-rails.cson
+++ b/keymaps/atom-rails.cson
@@ -10,3 +10,4 @@
 '.editor':
   'ctrl-alt-m': 'atom-rails:switch-to-model'
   'ctrl-alt-r': 'atom-rails:related'
+  'shift-alt-r': 'atom-rails:open-definition-file'

--- a/lib/atom-rails.coffee
+++ b/lib/atom-rails.coffee
@@ -1,5 +1,6 @@
 Model = require './model'
 Related = require './related'
+DefinitionOpener = require './definitionOpener'
 
 module.exports =
   atomRailsView: null
@@ -7,12 +8,19 @@ module.exports =
   activate: (state) ->
     atom.workspaceView.command "atom-rails:switch-to-model", => @switchToModel()
     atom.workspaceView.command "atom-rails:related", => @related()
+    atom.workspaceView.command "atom-rails:open-definition-file", =>
+      @openDefinitionFile()
 
   switchToModel: ->
     currentFile = atom.workspace.getActiveEditor().getPath()
     file = new Model(currentFile).path()
     atom.workspaceView.open(file) if file?
-    
+
+  openDefinitionFile: ->
+    opener = new DefinitionOpener
+    opener.openOrIgnore()
+
+
   related: ->
     currentFile = atom.workspace.getActiveEditor().getPath()
     file = new Related(currentFile).path()

--- a/lib/definitionOpener.coffee
+++ b/lib/definitionOpener.coffee
@@ -1,0 +1,24 @@
+class DefinitionOpener
+  getDefinition: ->
+    activeEditor = atom.workspace.getActiveEditor()
+    cursor = activeEditor.cursors[0]
+    activeEditor.getCursor()
+    activeEditor.getTextInRange(cursor.getCurrentWordBufferRange())
+
+  openOrIgnore: (callback)->
+    @potentialPath (path)->
+      atom.workspaceView.open(path)
+
+  potentialPath: (callback)-> # it does not trigger callback if no path found
+    definition = @getDefinition()
+    regexp = new RegExp(" *((class)|(module)){1}( +)#{definition}[^\\w]")
+    potentialPath = null
+    atom.project.scan regexp, {}, (result, error) ->
+      return if potentialPath?
+
+      result ||= {}
+      potentialPath = result.filePath
+      callback(potentialPath) if potentialPath?
+
+
+module.exports = DefinitionOpener

--- a/menus/atom-rails.cson
+++ b/menus/atom-rails.cson
@@ -6,6 +6,7 @@
       'label': 'atom-rails'
       'submenu': [
         { 'label': 'Switch To Model', 'command': 'atom-rails:switch-to-model' }
+        { 'label': 'Open definition file', 'command': 'atom-rails:open-definition-file' }
         { 'label': 'Related', 'command': 'atom-rails:related' }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Tom Kadwill",
   "activationEvents": [
     "atom-rails:switch-to-model",
-    "atom-rails:related"
+    "atom-rails:related",
+    "atom-rails:open-definition-file"
   ],
   "repository": "https://github.com/tomkadwill/atom-rails",
   "license": "MIT",


### PR DESCRIPTION
This is for #12 issue.
Usage: put cursor on class name (for example "User") and press 'alt-shift-R'. Atom rails will open first file that contains line "class User".

Currently works fine with one level class or module definitions. It will not work if you try to open by work "Admin::User" and you have defined user class as:

``` ruby
module Admin
  class User
  # ...
  end
end
```

but it should work fine if you defined your user class as:

``` ruby
class Admin::User
  # ...
end
```

P.S. I am ashamed that I did not add any tests. I will try to fix this in the future
